### PR TITLE
fix(build): bump AGP to 9.2.0 and drop kotlin.android plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 plugins {
-    id 'com.android.library' version '8.7.3' apply false
-    id 'org.jetbrains.kotlin.android' version '2.3.20' apply false
+    id 'com.android.library' version '9.2.0' apply false
 }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'com.android.library'
-    id 'org.jetbrains.kotlin.android'
     id 'maven-publish'
 }
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -26,10 +26,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
         test.java.srcDirs += 'src/test/kotlin'


### PR DESCRIPTION
## Summary
- Bump Android Gradle Plugin from 8.7.3 to 9.2.0.
- Remove the standalone `org.jetbrains.kotlin.android` plugin: AGP 9.0+ ships built-in Kotlin support, and Kotlin Gradle Plugin 2.3.x errors out when both are applied.

## Test plan
- [ ] CI Build job succeeds
- [ ] CI Test job succeeds
- [ ] Verify generated AAR still publishes via JitPack

Tracking: unhappychoice/oss-issue-opener#143

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Android build tooling to the latest version, enhancing compatibility with modern development standards and improving build stability
  * Streamlined build configuration by removing redundant plugin declarations, reducing configuration overhead

<!-- end of auto-generated comment: release notes by coderabbit.ai -->