### PR TITLE
chore: add CODEOWNERS for review request automation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @unhappychoice


### PR DESCRIPTION
Restores Dependabot review request behavior. The deprecated `reviewers:` field in `dependabot.yml` stopped working in late 2025 — CODEOWNERS is now the supported mechanism.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership configuration for repository maintenance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unhappychoice/RxSnackbar/pull/234)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->